### PR TITLE
Postgres numeric types now parsed as numbers rather than string default.

### DIFF
--- a/booking-module/database/index.js
+++ b/booking-module/database/index.js
@@ -5,7 +5,10 @@
 
 // module.exports = db;
 
-const { Pool } = require('pg');
+const { Pool, types } = require('pg');
+
+// takes db entries of type numeric, and casts them to numbers (otherwise, they'd be strings)
+types.setTypeParser(1700, value => Number(value));
 
 const pool = new Pool({
   database: 'bnb',


### PR DESCRIPTION
@SDC-BedAndBreakfastClub/sqluminati can you guys take a glance please? Small fix — I realized that the node-postgres client parses the numeric type as strings by default, extended it to parse them as numbers. Thanks!